### PR TITLE
Fix threading.Condition constructor

### DIFF
--- a/patches/pystub/threading.py
+++ b/patches/pystub/threading.py
@@ -1,4 +1,6 @@
 class Condition():
+    def __init__(self, lock=None): pass
+    
     def __enter__(self): pass
 
     def __exit__(self, _type, value, traceback): pass


### PR DESCRIPTION
Fix for #22.

`Queue.PriorityQueue` constructor depends on `Queue.Queue` constructor which [instantiates multiple `threading.Condtion` objects using the same lock](https://github.com/python/cpython/blob/5a29c5cc452e3fa52f48581094c7125d94d65cf6/Lib/Queue.py#L36). The stub `threading.Condition` constructor does not expect the lock argument, hence the issue.