### PR TITLE
Close context menu on item selection

### DIFF
--- a/renpy-shell.html
+++ b/renpy-shell.html
@@ -184,13 +184,20 @@
       /* Copyright (C) 2018, 2019, 2020, 2021  Sylvain Beucler */
 
       /* Context menu */
+      const menu = document.getElementById('ContextMenu');
       document.getElementById('ContextButton').addEventListener('click', function (e) {
-        var menu = document.getElementById('ContextMenu');
         if (menu.style.display == 'none')
           menu.style.display = 'block';
         else
           menu.style.display = 'none';
         e.preventDefault();
+      });
+
+      menu.addEventListener('click', function (e) {
+        if (e.target.tagName == 'A') {
+          // Close context menu when a menu item is selected
+          menu.style.display = 'none';
+        }
       });
 
       function onSavegamesImport(input) {


### PR DESCRIPTION
Currently, the context menu stays open after the user clicked on one of its item. This PR makes it behave like a typical menu which closes when one of its item is selected.