### PR TITLE
Adds js_cmd.js to web package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -378,12 +378,13 @@ pygame-example-py3-static: $(BUILD)/python3.built common-pygame-example-py3-stat
 ##
 # renpyweb-static-asyncify
 ##
-asyncify: $(BUILD)/python.built $(BUILD)/renpy.built common-renpy versionmark
+asyncify: $(BUILD)/python.built $(BUILD)/renpy.built common-renpy versionmark $(CURDIR)/js_cmd.js
 	$(EMCC) $(RENPY_OBJS) \
 	    $(RENPY_LDFLAGS) \
 	    $(ASYNCIFY_LDFLAGS) \
 	    -s INITIAL_MEMORY=128MB -s ALLOW_MEMORY_GROWTH=1 \
 	    -o $(BUILD)/t/index.html
+	cp -a $(CURDIR)/js_cmd.js $(BUILD)/t/
 
 
 # Experimental - doesn't work

--- a/scripts/install_in_renpy.sh
+++ b/scripts/install_in_renpy.sh
@@ -35,7 +35,7 @@ fi
 
 mkdir renpy/web
 
-for i in index.html index.js index.wasm pyapp.data pyapp-data.js pythonhome.data pythonhome-data.js renpyweb-version.txt; do
+for i in index.html index.js index.wasm pyapp.data pyapp-data.js pythonhome.data pythonhome-data.js renpyweb-version.txt js_cmd.js; do
     cp build/t/$i renpy/web/$i
 done
 


### PR DESCRIPTION
The script `js_cmd.js` is missing from the web package, so importing saves fails in new builds. Dunno what is best: add the script file to the web package or inline its content in `renpy-shell.html`. The latter is generally considered to be a bad practice, so I've opted for the former. I'm okay to inline the script if you prefer (this removes one small HTTP request and is tolerated for single page web apps).